### PR TITLE
fix: fetch more parameters than the default 10

### DIFF
--- a/lib/services/parameter-store.service.ts
+++ b/lib/services/parameter-store.service.ts
@@ -16,13 +16,22 @@ export class ParameterStoreService {
     path: string,
     decrypt = false,
   ): Promise<Parameter[]> {
-    const getParameters = new GetParametersByPathCommand({
-      Path: path,
-      WithDecryption: decrypt,
-    });
+    let allParameters: Parameter[] = [];
+    let nextParametersToken: string | undefined;
+    do {
+      const getParameters = new GetParametersByPathCommand({
+        Path: path,
+        WithDecryption: decrypt,
+        NextToken: nextParametersToken,
+      });
 
-    const { Parameters = [] } = await this.client.send(getParameters);
+      const { Parameters = [], NextToken } = await this.client.send(
+        getParameters,
+      );
+      allParameters = allParameters.concat(Parameters);
+      nextParametersToken = NextToken;
+    } while (Boolean(nextParametersToken));
 
-    return Parameters;
+    return allParameters;
   }
 }


### PR DESCRIPTION
Solves #4 

- By default, GetParametersByPathCommand only retrieves the first 10 parameters.
- Call GetParametersByPathCommand until "NextToken" is undefined (no more parameters to read for that config path), [docs](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html#API_GetParametersByPath_RequestSyntax)